### PR TITLE
Disable \Sabre\CalDAV\Schedule\Plugin

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -168,7 +168,6 @@ class Server {
         if ($this->enableCalDAV) {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-            $this->server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
         }
         if ($this->enableCardDAV) {
             $this->server->addPlugin(new \Sabre\CardDAV\Plugin());


### PR DESCRIPTION
Baikal is no Groupware software, thus `\Sabre\CalDAV\Schedule\Plugin` can't provide any meaningful functionality "as is". `\Sabre\CalDAV\Schedule\Plugin` relies on additional "transport" plugins to actually send invitations to attendees of events (see http://sabre.io/dav/scheduling/ for some details). AFAIK it was planned for Baikal 2 to additionally load `\Sabre\CalDAV\Schedule\IMipPlugin`, however, I don't think that RFC 6047 (the standard behind `\Sabre\CalDAV\Schedule\IMipPlugin`) is a good idea at all. The server sends invitations, but there's usually no way for the server to receive responses - so, it rather sends notifications than invitations? 😒 `sabre/dav` additionally supports server-to-server delivery, but afaik this isn't widely supported anyway. Furthermore it obviously won't work with local calendars.

So, what's the reason for removing the plugin besides "it doesn't provide any functionality"?

I don't know a single calendar client that supports managing attendees, but not sending invitations. By loading `\Sabre\CalDAV\Schedule\Plugin`, Baikal claims to support scheduling - what is, as elucidated above, simply not the case. However, the calendar client (e.g. Thunderbird/Lightning) *thinks* Baikal supports scheduling and that invitations are handled by the server - and consequently disables its own invitation system. There's no way to overwrite this behavior - because it's simply not the client's fault, it's the server's (i.e. Baikal's) fault to falsely claim support for scheduling.

By disabling `\Sabre\CalDAV\Schedule\Plugin` Baikal stops claiming support for scheduling, thus calendar clients will start sending invitations again.

Closes #685
Closes #655
Fixes #626
(+ many already closed, but never fixed Issues :wink:)